### PR TITLE
Library store

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,49 @@
+name: Build Android APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'EAS build profile — "preview" produces a standalone installable APK; "development" produces a dev-client APK that requires a running Expo dev server'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - development
+
+jobs:
+  build:
+    name: Build Android APK (${{ inputs.profile }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build APK via EAS
+        id: eas-build
+        run: |
+          OUTPUT=$(eas build --platform android --profile ${{ inputs.profile }} --non-interactive 2>&1 | tee /dev/stderr)
+          BUILD_URL=$(echo "$OUTPUT" | grep -oE 'https://expo\.dev/accounts/[^[:space:]]+' | tail -1)
+          echo "build-url=$BUILD_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Print APK download URL
+        if: steps.eas-build.outputs.build-url != ''
+        run: echo "APK download URL ${{ steps.eas-build.outputs.build-url }}"

--- a/app.json
+++ b/app.json
@@ -1,6 +1,7 @@
 {
   "expo": {
     "name": "SimpleMediaBrowser",
+    "owner": "kallb123",
     "slug": "SimpleMediaBrowser",
     "version": "1.0.0",
     "orientation": "portrait",

--- a/app/(drawer)/index.tsx
+++ b/app/(drawer)/index.tsx
@@ -7,20 +7,13 @@ import { useSelector } from 'react-redux';
 import { selectDirectory, selectPassword } from '@/store/settingsReducer';
 import { FlashList } from '@shopify/flash-list';
 import { FileInfo, getInfoAsync, StorageAccessFramework } from 'expo-file-system';
-import { FileScanner } from '@/scripts/fileScanner';
-
-interface MediaObject {
-  filename: string
-  path: string
-  parsedPath: string
-  isDirectory: boolean
-}
+import { FileScanner, IMediaObject } from '@/scripts/FileScanner';
 
 export default function HomeScreen() {
   const directory = useSelector(selectDirectory);
   const settingsPassword = useSelector(selectPassword);
 
-  const [mediaList, setMediaList] = useState([] as MediaObject[]);
+  const [mediaList, setMediaList] = useState([] as IMediaObject[]);
 
   useEffect(() => {
     // Check whether there's a directory to read

--- a/app/(drawer)/index.tsx
+++ b/app/(drawer)/index.tsx
@@ -8,6 +8,7 @@ import { selectDirectory, selectPassword } from '@/store/settingsReducer';
 import { FlashList } from '@shopify/flash-list';
 import { FileInfo, getInfoAsync, StorageAccessFramework } from 'expo-file-system';
 import { FileScanner, IMediaObject } from '@/scripts/FileScanner';
+import { MediaItem } from '@/components/UI/MediaItem';
 
 export default function HomeScreen() {
   const directory = useSelector(selectDirectory);
@@ -39,7 +40,8 @@ export default function HomeScreen() {
           data={mediaList}
           renderItem={({ item }) => {
             return (
-              <ThemedText><Link href={item.path as Href}>{item.filename}</Link></ThemedText>
+              <MediaItem mediaObject={item} />
+              // <ThemedText><Link href={item.path as Href}>{item.filename}</Link></ThemedText>
             )
           }}
           estimatedItemSize={200}

--- a/app/(drawer)/index.tsx
+++ b/app/(drawer)/index.tsx
@@ -56,7 +56,7 @@ export default function HomeScreen() {
         <ThemedView style={styles.stepContainer}>
           <ThemedText type="subtitle">Problem</ThemedText>
           {
-            directory ? (
+            directory ? ( // TODO: Need to insert a loading status in here
               <ThemedText>
                 Your library directory is empty or invalid, set it up in <Link href={settingsPassword ? "/(drawer)/settingsprompt" : "/settings"}>Settings</Link>.
               </ThemedText>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -10,6 +10,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { contentTypes, dataSources, selectDataSource, selectDirectory, selectMediaStructure, selectMediaType, selectPassword, selectViewOrientation, selectViewScale, setDataSource, setDirectory, setMediaStructure, setMediaType, setPassword, setViewOrientation, setViewScale, viewOrientations, viewTypes } from '@/store/settingsReducer';
 import SelectDropdown from 'react-native-select-dropdown';
 import Slider from '@react-native-community/slider';
+import { FileScanner } from '@/scripts/fileScanner';
 
 export default function SettingsPrompt() {
   const [directory, setLocalDirectory] = useState(null as string | null);
@@ -107,6 +108,12 @@ export default function SettingsPrompt() {
     setLocalDirectory(selectedDir.uri);
   }, []);
 
+  const scanNow = useCallback(async () => {
+    if (directory) {
+      await FileScanner.getInstance().scanFolder(directory);
+    }
+  }, []);
+
   const handleUIScaleChange = (value: number) => {
     setLocalViewScale(11-value);
   }
@@ -137,6 +144,12 @@ export default function SettingsPrompt() {
         />
       </ThemedView>
       <ThemedText>Directory is: {directory}</ThemedText>
+      <ThemedView style={styles.titleContainer}>
+        <Button
+            title="Rescan now"
+            onPress={scanNow}
+        />
+      </ThemedView>
       <ThemedView style={styles.titleContainer}>
         <ThemedText>Media type:</ThemedText>
         <SelectDropdown

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -10,7 +10,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { contentTypes, dataSources, selectDataSource, selectDirectory, selectMediaStructure, selectMediaType, selectPassword, selectViewOrientation, selectViewScale, setDataSource, setDirectory, setMediaStructure, setMediaType, setPassword, setViewOrientation, setViewScale, viewOrientations, viewTypes } from '@/store/settingsReducer';
 import SelectDropdown from 'react-native-select-dropdown';
 import Slider from '@react-native-community/slider';
-import { FileScanner } from '@/scripts/fileScanner';
+import { FileScanner } from '@/scripts/FileScanner';
 
 export default function SettingsPrompt() {
   const [directory, setLocalDirectory] = useState(null as string | null);

--- a/components/UI/DirectoryLink.tsx
+++ b/components/UI/DirectoryLink.tsx
@@ -1,0 +1,13 @@
+import { IMediaObject } from '@/scripts/FileScanner';
+import { ThemedText } from '../ThemedText';
+import { Href, Link } from 'expo-router';
+
+export type MediaItemProps =  {
+  mediaObject: IMediaObject
+};
+
+export function DirectoryLink({ mediaObject }: MediaItemProps) {
+  return (
+    <ThemedText><Link href={mediaObject.path as Href}>{mediaObject.filename}</Link></ThemedText>
+  );
+}

--- a/components/UI/FileLink.tsx
+++ b/components/UI/FileLink.tsx
@@ -1,0 +1,13 @@
+import { IMediaObject } from '@/scripts/FileScanner';
+import { ThemedText } from '../ThemedText';
+import { Href, Link } from 'expo-router';
+
+export type MediaItemProps =  {
+  mediaObject: IMediaObject
+};
+
+export function FileLink({ mediaObject }: MediaItemProps) {
+  return (
+    <ThemedText><Link href={mediaObject.path as Href}>{mediaObject.filename}</Link></ThemedText>
+  );
+}

--- a/components/UI/MediaItem.tsx
+++ b/components/UI/MediaItem.tsx
@@ -1,0 +1,18 @@
+import { IMediaObject } from '@/scripts/FileScanner';
+import { ThemedText } from '../ThemedText';
+import { DirectoryLink } from './DirectoryLink';
+import { FileLink } from './FileLink';
+
+export type MediaItemProps =  {
+  mediaObject: IMediaObject
+};
+
+export function MediaItem({ mediaObject, ...rest }: MediaItemProps) {
+  return mediaObject.isDirectory ? (
+    <DirectoryLink mediaObject={mediaObject}></DirectoryLink>
+  )
+  :
+  (
+    <FileLink mediaObject={mediaObject}></FileLink>
+  )
+}

--- a/eas.json
+++ b/eas.json
@@ -14,6 +14,5 @@
   },
   "submit": {
     "production": {}
-  },
-  "owner": "kallb123"
+  }
 }

--- a/eas.json
+++ b/eas.json
@@ -14,5 +14,6 @@
   },
   "submit": {
     "production": {}
-  }
+  },
+  "owner": "kallb123"
 }

--- a/scripts/FileScanner.ts
+++ b/scripts/FileScanner.ts
@@ -1,30 +1,8 @@
 import { FileInfo, getInfoAsync, StorageAccessFramework } from "expo-file-system";
 import { store } from "@/store/store";
-import { setScanList } from "@/store/libraryReducer";
-
-export interface IMediaLibrary {
-    [show: string] : IMediaShow;
-}
-
-export interface IMediaShow {
-    ids: {
-        tvdb: string | null;
-        imdb: string | null;
-    }
-    title: string;
-    year: number;
-    poster: string;
-    seasons: { [season: string] : IMediaSeason; };
-}
-
-export interface IMediaSeason {
-    ids: {
-        tvdb: string | null;
-        imdb: string | null;
-    }
-    seasonNumber: number;
-    episodes: { [episode: string] : IMediaObject; };
-}
+import { setScanList, setMediaLibrary } from "@/store/libraryReducer";
+import type { IMediaLibrary, IMediaShow, IMediaSeason } from "@/store/libraryReducer";
+import type { viewTypes } from "@/store/settingsReducer";
 
 export interface IMediaObject {
     ids: {
@@ -39,13 +17,37 @@ export interface IMediaObject {
     isDirectory: boolean
 }
 
+// Re-export library types so other modules can import them from here
+export type { IMediaLibrary, IMediaShow, IMediaSeason };
+
+const VIDEO_EXTENSIONS = new Set([
+    '.mkv', '.mp4', '.avi', '.mov', '.m4v', '.wmv', '.flv',
+    '.ts', '.m2ts', '.webm', '.mpg', '.mpeg', '.3gp',
+]);
+
+/** Maximum folder depth to recurse into during a scan. Protects against infinite symlink loops. */
+const MAX_SCAN_DEPTH = 8;
+
+interface ParsedMetadata {
+    showName: string;
+    season: number;
+    episode: number;
+    title: string;
+}
+
+/** A file collected during recursive scanning, carrying its relative path parts. */
+interface IScannedFile extends IMediaObject {
+    /** Path segments relative to the root scan directory (does not include filename). */
+    relativePathParts: string[];
+}
+
 export class FileScanner {
     static myInstance: FileScanner | null = null;
 
     _userID = "";
 
     /**
-     * @returns {CommonDataManager}
+     * @returns {FileScanner}
      */
     static getInstance(): FileScanner {
         if (this.myInstance == null) {
@@ -90,7 +92,258 @@ export class FileScanner {
 
         store.dispatch(setScanList(filtered.map(f => f.path)));
 
+        // Recursively collect all media files and build the library
+        const allMediaFiles = await this.collectAllMediaFiles(directory);
+        const viewType: viewTypes = store.getState().settingsReducer?.viewType ?? 'show/season';
+        const library = this.buildLibrary(allMediaFiles, viewType);
+        store.dispatch(setMediaLibrary(library));
+
         return filtered;
+    }
+
+    // ─── Recursive collection ────────────────────────────────────────────────
+
+    private async collectAllMediaFiles(rootDirectory: string): Promise<IScannedFile[]> {
+        const result: IScannedFile[] = [];
+        await this.recursiveCollect(rootDirectory, [], result, 0);
+        return result;
+    }
+
+    private async recursiveCollect(
+        directory: string,
+        relativePathParts: string[],
+        result: IScannedFile[],
+        depth: number,
+    ): Promise<void> {
+        if (depth > MAX_SCAN_DEPTH) return; // Safety guard against deeply nested structures
+
+        let contents: string[];
+        try {
+            contents = await StorageAccessFramework.readDirectoryAsync(directory);
+        } catch {
+            return; // Directory not accessible
+        }
+
+        const infoList = await Promise.all(
+            contents.map(async (c) => {
+                try {
+                    return await getInfoAsync(c);
+                } catch {
+                    // SAF directories sometimes fail getInfoAsync; treat as directory
+                    const info: FileInfo = { uri: c, isDirectory: true, exists: true, size: 0, modificationTime: 0 };
+                    return info;
+                }
+            }),
+        );
+
+        for (const info of infoList) {
+            const uri = decodeURIComponent(info.uri);
+            const filename = uri.substring(uri.lastIndexOf('/') + 1);
+
+            if (filename.charAt(0) === '.') continue; // Skip hidden entries
+
+            if (info.isDirectory) {
+                await this.recursiveCollect(info.uri, [...relativePathParts, filename], result, depth + 1);
+            } else if (this.isMediaFile(filename)) {
+                result.push({
+                    ids: { tvdb: null, imdb: null },
+                    title: '',
+                    episodeNumber: 0,
+                    filename,
+                    path: info.uri,
+                    parsedPath: uri,
+                    isDirectory: false,
+                    relativePathParts,
+                });
+            }
+        }
+    }
+
+    private isMediaFile(filename: string): boolean {
+        const dotIndex = filename.lastIndexOf('.');
+        if (dotIndex === -1) return false;
+        const ext = filename.substring(dotIndex).toLowerCase();
+        return VIDEO_EXTENSIONS.has(ext);
+    }
+
+    // ─── Library building ────────────────────────────────────────────────────
+
+    buildLibrary(files: IScannedFile[], viewType: viewTypes): IMediaLibrary {
+        const library: IMediaLibrary = {};
+
+        for (const file of files) {
+            const metadata = this.parseMediaFile(file, viewType);
+            if (!metadata) continue;
+
+            const { showName, season, episode, title } = metadata;
+
+            if (!library[showName]) {
+                library[showName] = {
+                    ids: { tvdb: null, imdb: null },
+                    title: showName,
+                    year: 0,
+                    poster: '',
+                    seasons: {},
+                };
+            }
+
+            const seasonKey = `s${String(season).padStart(2, '0')}`;
+            if (!library[showName].seasons[seasonKey]) {
+                library[showName].seasons[seasonKey] = {
+                    ids: { tvdb: null, imdb: null },
+                    seasonNumber: season,
+                    episodes: {},
+                };
+            }
+
+            const episodeKey = `e${String(episode).padStart(2, '0')}`;
+            // Avoid overwriting an existing entry with the same key
+            if (!library[showName].seasons[seasonKey].episodes[episodeKey]) {
+                // Strip the internal relativePathParts field before storing
+                const { relativePathParts, ...mediaObj } = file;
+                library[showName].seasons[seasonKey].episodes[episodeKey] = {
+                    ...mediaObj,
+                    title: title || file.filename,
+                    episodeNumber: episode,
+                };
+            }
+        }
+
+        return library;
+    }
+
+    private parseMediaFile(file: IScannedFile, viewType: viewTypes): ParsedMetadata | null {
+        // Filename-based parsing takes priority (e.g. ShowName.S01E05.mkv)
+        const fromFilename = this.parseFilename(file.filename);
+        if (fromFilename) return fromFilename;
+
+        // Fall back to inferring from the directory structure
+        return this.parseFromPath(file, viewType);
+    }
+
+    // ─── Filename parser ─────────────────────────────────────────────────────
+
+    /**
+     * Parse common TV filename patterns:
+     *   Show.Name.S01E05.Episode.Title.mkv   (SxxExx)
+     *   Show.Name.1x05.Episode.Title.mkv     (NxNN)
+     */
+    parseFilename(filename: string): ParsedMetadata | null {
+        // Remove extension for easier matching
+        const withoutExt = filename.replace(/\.[^.]+$/, '');
+
+        // SxxExx pattern — requires a separator before [Ss] so numeric show names don't false-match.
+        // Season: up to 2 digits (realistic max ~99); episode: up to 3 digits (e.g. anime ep 100+).
+        const sxxMatch = withoutExt.match(
+            /^(.*?)[\.\s_-]+\b[Ss](\d{1,2})[Ee](\d{1,3})\b(?:[\.\s_-]+(.*))?$/,
+        );
+        if (sxxMatch) {
+            return {
+                showName: this.cleanName(sxxMatch[1]),
+                season: parseInt(sxxMatch[2], 10),
+                episode: parseInt(sxxMatch[3], 10),
+                title: sxxMatch[4] ? this.cleanName(sxxMatch[4]) : '',
+            };
+        }
+
+        // NxNN pattern — requires a separator before the season digit so numbers inside show names
+        // don't false-match. Season: up to 2 digits; episode: up to 3 digits.
+        const nxnnMatch = withoutExt.match(
+            /^(.*?)[\.\s_-]+\b(\d{1,2})x(\d{1,3})\b(?:[\.\s_-]+(.*))?$/,
+        );
+        if (nxnnMatch) {
+            return {
+                showName: this.cleanName(nxnnMatch[1]),
+                season: parseInt(nxnnMatch[2], 10),
+                episode: parseInt(nxnnMatch[3], 10),
+                title: nxnnMatch[4] ? this.cleanName(nxnnMatch[4]) : '',
+            };
+        }
+
+        return null;
+    }
+
+    // ─── Path-based parser ───────────────────────────────────────────────────
+
+    /**
+     * Infer show/season/episode from the directory hierarchy.
+     *
+     * viewType meanings (as set in settings):
+     *   flat        – all files are siblings, no folder hierarchy
+     *   show        – rootDir/ShowName/episode.mkv
+     *   show+season – rootDir/ShowName Season N/episode.mkv
+     *   show/season – rootDir/ShowName/Season N/episode.mkv
+     */
+    private parseFromPath(file: IScannedFile, viewType: viewTypes): ParsedMetadata | null {
+        const parts = file.relativePathParts;
+        const baseTitle = file.filename.replace(/\.[^.]+$/, '').replace(/[\._-]+/g, ' ').trim();
+
+        // Try to extract an episode number from the filename.
+        // Word boundary (\b) prevents matching digits inside unrelated words.
+        // [Ee][Pp]? optionally matches 'p/P', covering 'e5', 'E5', 'ep5', 'EP5', etc.
+        const epMatch = file.filename.match(/\b[Ee][Pp]?(\d{1,3})\b/);
+        const episode = epMatch ? parseInt(epMatch[1], 10) : 0;
+
+        switch (viewType) {
+            case 'flat':
+                // No usable folder structure; cannot infer show/season
+                return null;
+
+            case 'show':
+                // rootDir/ShowName/episode.mkv
+                if (parts.length >= 1) {
+                    return { showName: parts[0], season: 1, episode, title: baseTitle };
+                }
+                return null;
+
+            case 'show+season': {
+                // rootDir/ShowName Season N/episode.mkv
+                if (parts.length >= 1) {
+                    const folderName = parts[0];
+                    // Single capture group via non-capturing alternatives:
+                    // matches 'Season N' (word) or a word-bounded 'SN' abbreviation at end.
+                    const seasonMatch = folderName.match(
+                        /(?:[Ss]eason\s*|\b[Ss])(\d+)$/,
+                    );
+                    const season = seasonMatch ? parseInt(seasonMatch[1], 10) : 1;
+                    const showName = seasonMatch
+                        ? folderName.slice(0, folderName.lastIndexOf(seasonMatch[0])).trim()
+                        : folderName;
+                    return { showName: showName || folderName, season, episode, title: baseTitle };
+                }
+                return null;
+            }
+
+            case 'show/season':
+                // rootDir/ShowName/Season N/episode.mkv
+                if (parts.length >= 2) {
+                    const showName = parts[0];
+                    const seasonFolder = parts[1];
+                    // Prefer an explicit 'Season N' word; otherwise take the first digit run.
+                    const namedSeasonMatch = seasonFolder.match(/[Ss]eason\s*(\d+)/i);
+                    const rawNumberMatch = seasonFolder.match(/(\d+)/);
+                    const seasonStr = namedSeasonMatch
+                        ? namedSeasonMatch[1]
+                        : rawNumberMatch?.[1] ?? '1';
+                    const season = parseInt(seasonStr, 10);
+                    return { showName, season, episode, title: baseTitle };
+                }
+                if (parts.length === 1) {
+                    // File sits directly in show folder (no season subfolder)
+                    return { showName: parts[0], season: 1, episode, title: baseTitle };
+                }
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    // ─── Utilities ───────────────────────────────────────────────────────────
+
+    /** Replace dots/underscores with spaces and trim the string. */
+    private cleanName(raw: string): string {
+        return raw.replace(/[\._]+/g, ' ').trim();
     }
 
     getUserID() {

--- a/scripts/FileScanner.ts
+++ b/scripts/FileScanner.ts
@@ -1,4 +1,6 @@
 import { FileInfo, getInfoAsync, StorageAccessFramework } from "expo-file-system";
+import { store } from "@/store/store";
+import { setScanList } from "@/store/libraryReducer";
 
 export interface IMediaLibrary {
     [show: string] : IMediaShow;
@@ -86,7 +88,9 @@ export class FileScanner {
           return c;
         });
 
-         return filtered;
+        store.dispatch(setScanList(filtered.map(f => f.path)));
+
+        return filtered;
     }
 
     getUserID() {

--- a/store/libraryReducer.ts
+++ b/store/libraryReducer.ts
@@ -60,10 +60,13 @@ export const settingsSlice = createSlice({
     clearScanList: (state, action: PayloadAction<string>) => {
       state.scanList = [];
     },
+    setMediaLibrary: (state, action: PayloadAction<IMediaLibrary>) => {
+      state.mediaLibrary = action.payload;
+    },
   },
 })
 
-export const { addToScanList, setScanList, clearScanList } = settingsSlice.actions;
+export const { addToScanList, setScanList, clearScanList, setMediaLibrary } = settingsSlice.actions;
 
 // Other code such as selectors can use the imported `RootState` type
 export const selectScanList = (state: RootState) => state.libraryReducer.scanList;

--- a/store/libraryReducer.ts
+++ b/store/libraryReducer.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { RootState } from './store';
+import { IMediaObject } from '@/scripts/FileScanner';
 
 export interface IMediaLibrary {
     [show: string] : IMediaShow;
@@ -23,19 +24,6 @@ export interface IMediaSeason {
     }
     seasonNumber: number;
     episodes: { [episode: string] : IMediaObject; };
-}
-
-export interface IMediaObject {
-    ids: {
-        tvdb: string | null;
-        imdb: string | null;
-    }
-    episodeNumber: number;
-    title: string;
-    filename: string
-    path: string
-    parsedPath: string
-    isDirectory: boolean
 }
 
 export type IRawScanList = string[];

--- a/store/libraryReducer.ts
+++ b/store/libraryReducer.ts
@@ -1,0 +1,84 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from './store';
+
+export interface IMediaLibrary {
+    [show: string] : IMediaShow;
+}
+
+export interface IMediaShow {
+    ids: {
+        tvdb: string | null;
+        imdb: string | null;
+    }
+    title: string;
+    year: number;
+    poster: string;
+    seasons: { [season: string] : IMediaSeason; };
+}
+
+export interface IMediaSeason {
+    ids: {
+        tvdb: string | null;
+        imdb: string | null;
+    }
+    seasonNumber: number;
+    episodes: { [episode: string] : IMediaObject; };
+}
+
+export interface IMediaObject {
+    ids: {
+        tvdb: string | null;
+        imdb: string | null;
+    }
+    episodeNumber: number;
+    title: string;
+    filename: string
+    path: string
+    parsedPath: string
+    isDirectory: boolean
+}
+
+export type IRawScanList = string[];
+
+export type contentTypes = 'tv' | 'movie';
+export type dataSources = 'tvdb';
+export type viewTypes = 'flat' | 'show' | 'show+season' | 'show/season';
+export type viewOrientations = 'poster' | 'banner';
+
+// Define a type for the slice state
+interface LibraryState {
+  mediaLibrary: IMediaLibrary;
+  scanList: IRawScanList;
+}
+
+// Define the initial state using that type
+const initialState: LibraryState = {
+  mediaLibrary: {},
+  scanList: []
+}
+
+export const settingsSlice = createSlice({
+  name: 'settings',
+  // `createSlice` will infer the state type from the `initialState` argument
+  initialState,
+  reducers: {
+    // Use the PayloadAction type to declare the contents of `action.payload`
+    addToScanList: (state, action: PayloadAction<string>) => {
+      state.scanList.push(action.payload);
+    },
+    setScanList: (state, action: PayloadAction<string[]>) => {
+      state.scanList = action.payload;
+    },
+    clearScanList: (state, action: PayloadAction<string>) => {
+      state.scanList = [];
+    },
+  },
+})
+
+export const { addToScanList, setScanList, clearScanList } = settingsSlice.actions;
+
+// Other code such as selectors can use the imported `RootState` type
+export const selectScanList = (state: RootState) => state.libraryReducer.scanList;
+export const selectMediaLibrary = (state: RootState) => state.libraryReducer.mediaLibrary;
+
+export default settingsSlice.reducer

--- a/store/store.ts
+++ b/store/store.ts
@@ -2,6 +2,7 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import settingsReducer from './settingsReducer'
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { FLUSH, PAUSE, PERSIST, persistReducer, persistStore, PURGE, REGISTER, REHYDRATE } from 'redux-persist';
+import libraryReducer from './libraryReducer';
 
 // https://dev.to/shreyvijayvargiya/react-native-redux-tool-kit-asyncstorage-210e
 // https://stackoverflow.com/a/62610422
@@ -11,6 +12,7 @@ const persistConfig = {
 };
 const rootReducer = combineReducers({
   settingsReducer,
+  libraryReducer
 });
 
 export const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the media scanning and library-building logic, alongside UI improvements for browsing and managing media files. The main changes include a new recursive file scanner with robust filename and folder parsing, a normalized Redux state for the media library, and component refactoring for better separation of concerns.

**Media scanning and library management:**

* Introduced a new `FileScanner` class that recursively scans user-selected directories for media files, parses metadata from filenames and folder structures, and builds a normalized media library object. The scanner supports multiple folder layouts and includes safeguards against infinite recursion. (`scripts/FileScanner.ts` [[1]](diffhunk://#diff-3b980e2b5ab180aa31fd17eae1c249d2a648ea472cbc826fd5f1c1045c19721cL2-R5) [[2]](diffhunk://#diff-3b980e2b5ab180aa31fd17eae1c249d2a648ea472cbc826fd5f1c1045c19721cR20-R50) [[3]](diffhunk://#diff-3b980e2b5ab180aa31fd17eae1c249d2a648ea472cbc826fd5f1c1045c19721cR93-R348)
* Added a new Redux slice (`libraryReducer.ts`) to store the media library and scan results, with selectors and actions for updating scan lists and the library structure. This centralizes media state management for the app. (`store/libraryReducer.ts` [store/libraryReducer.tsR1-R75](diffhunk://#diff-40f4e8a8f80bdd58b33b8efb983f86b694dc237a01f71c236b46cbd4bf572856R1-R75))

**UI and component refactoring:**

* Refactored the media list rendering in the home screen to use a new `MediaItem` component, which delegates to `DirectoryLink` or `FileLink` based on whether the item is a directory or file. This improves code clarity and separation of UI logic. (`app/(drawer)/index.tsx` [[1]](diffhunk://#diff-09726094c006e2b033f535b47215da3a029005d93e3397522e9d9a85da24bd07L10-R17) [[2]](diffhunk://#diff-09726094c006e2b033f535b47215da3a029005d93e3397522e9d9a85da24bd07L49-R44) `components/UI/MediaItem.tsx` [[3]](diffhunk://#diff-1826bda364740ec8daedb461e402589345206e6f6673d6d69f9c86b25a72a903R1-R18) `components/UI/DirectoryLink.tsx` [[4]](diffhunk://#diff-75873b64551def2c8f5e505cc13c55e8cf5a538d0e8927293ef2002169c32e05R1-R13) `components/UI/FileLink.tsx` [[5]](diffhunk://#diff-dd890b5b94b2045f23476797ea152916917375b561e148ffc0c83d5dea3a8991R1-R13)

**Settings and user actions:**

* Added a "Rescan now" button to the settings screen, allowing users to manually trigger a media library rescan. (`app/settings.tsx` [[1]](diffhunk://#diff-b6973a9fa20a2134cc7414d5e91704760b3bb152ff388fb18bf186cfae76a1d5R13) [[2]](diffhunk://#diff-b6973a9fa20a2134cc7414d5e91704760b3bb152ff388fb18bf186cfae76a1d5R111-R116) [[3]](diffhunk://#diff-b6973a9fa20a2134cc7414d5e91704760b3bb152ff388fb18bf186cfae76a1d5R147-R152)

**DevOps and configuration:**

* Added a new GitHub Actions workflow (`.github/workflows/build-apk.yml`) for building Android APKs using EAS, with support for both preview and development profiles. (`.github/workflows/build-apk.yml` [.github/workflows/build-apk.ymlR1-R49](diffhunk://#diff-ef7f8ebab0dfb82e33c5d4e340e918cc31a840751f20f27f0bf94870d3fb147bR1-R49))
* Specified the Expo owner field in `app.json` for improved project ownership and EAS integration. (`app.json` [app.jsonR4](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5R4))

These changes lay the foundation for robust media management and improved user experience in browsing and organizing media content.