### PR TITLE
Add GitHub Actions workflow to build Android APK via EAS (#2)

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,49 @@
+name: Build Android APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'EAS build profile — "preview" produces a standalone installable APK; "development" produces a dev-client APK that requires a running Expo dev server'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - development
+
+jobs:
+  build:
+    name: Build Android APK (${{ inputs.profile }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build APK via EAS
+        id: eas-build
+        run: |
+          OUTPUT=$(eas build --platform android --profile ${{ inputs.profile }} --non-interactive 2>&1 | tee /dev/stderr)
+          BUILD_URL=$(echo "$OUTPUT" | grep -oE 'https://expo\.dev/accounts/[^[:space:]]+' | tail -1)
+          echo "build-url=$BUILD_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Print APK download URL
+        if: steps.eas-build.outputs.build-url != ''
+        run: echo "APK download URL ${{ steps.eas-build.outputs.build-url }}"


### PR DESCRIPTION
* Add GitHub Actions workflow to build dev/preview Android APK via EAS

Agent-Logs-Url: https://github.com/Kallb123/SimpleMediaBrowser/sessions/7ab27d29-abfa-4e16-a1c2-0e1b62727889



* Fix workflow: add permissions block and surface APK download URL

Agent-Logs-Url: https://github.com/Kallb123/SimpleMediaBrowser/sessions/7ab27d29-abfa-4e16-a1c2-0e1b62727889



---------