### PR TITLE
Add toggle for thumbnail generation

### DIFF
--- a/src/app/firsttime.tsx
+++ b/src/app/firsttime.tsx
@@ -1,4 +1,4 @@
-import { Image, StyleSheet, Button } from 'react-native';
+import { Image, StyleSheet, Button, Switch } from 'react-native';
 import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
@@ -9,13 +9,14 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useCallback, useState } from 'react';
 import { StorageKeys } from '@/constants/StorageKeys';
 import { useDispatch } from 'react-redux';
-import { setPassword } from '@/store/settingsReducer';
+import { setPassword, setEnableThumbnailGeneration } from '@/store/settingsReducer';
 import { AddMediaSource } from '@/components/ui/AddMediaSource';
 import { logger } from '@/scripts/Logger';
 
 export default function FirstTime() {
   const [password, onChangePassword] = useState(null as string | null);
   const [sourceAdded, setSourceAdded] = useState(false);
+  const [enableThumbnailGeneration, setEnableThumbnailGenerationLocal] = useState(false);
   const dispatch = useDispatch();
 
   logger.log('FirstTime', 'FirstTime screen rendered');
@@ -25,10 +26,11 @@ export default function FirstTime() {
     if (password) {
       dispatch(setPassword(password));
     }
+    dispatch(setEnableThumbnailGeneration(enableThumbnailGeneration));
     await AsyncStorage.setItem(StorageKeys.FIRST_TIME_SETUP_KEY, JSON.stringify(false));
     logger.log('FirstTime', 'First-time setup key written to AsyncStorage. Navigating to home.');
     router.replace('/(drawer)');
-  }, [password, dispatch]);
+  }, [password, enableThumbnailGeneration, dispatch]);
 
   return (
     <ParallaxScrollView
@@ -65,6 +67,16 @@ export default function FirstTime() {
           secureTextEntry={true}
         />
       </ThemedView>
+      <ThemedView style={styles.titleContainer}>
+        <ThemedText>Generate video thumbnails:</ThemedText>
+        <Switch
+          value={enableThumbnailGeneration}
+          onValueChange={setEnableThumbnailGenerationLocal}
+        />
+      </ThemedView>
+      <ThemedText style={styles.addedNote}>
+        Off by default. You can change this later in Settings.
+      </ThemedText>
       <ThemedView style={styles.titleContainer}>
         <Button
             title="Finished, Go Home"

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -1,5 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Button, StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { Button, StyleSheet, Text, View, TouchableOpacity, Switch } from 'react-native';
 import { ThemedTextInput } from '@/components/ThemedTextInput';
 import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
@@ -7,7 +7,7 @@ import { ThemedView } from '@/components/ThemedView';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { router } from 'expo-router';
 import { useDispatch, useSelector } from 'react-redux';
-import { dataSources, selectDataSource, selectMediaSources, selectMediaStructure, selectPassword, selectViewOrientation, selectViewScale, setDataSource, setMediaStructure, setPassword, setViewOrientation, setViewScale, viewOrientations, viewTypes, removeMediaSource, selectTmdbApiKey, setTmdbApiKey, defaultPages, selectDefaultPage, setDefaultPage } from '@/store/settingsReducer';
+import { dataSources, selectDataSource, selectMediaSources, selectMediaStructure, selectPassword, selectViewOrientation, selectViewScale, setDataSource, setMediaStructure, setPassword, setViewOrientation, setViewScale, viewOrientations, viewTypes, removeMediaSource, selectTmdbApiKey, setTmdbApiKey, defaultPages, selectDefaultPage, setDefaultPage, selectEnableThumbnailGeneration, setEnableThumbnailGeneration } from '@/store/settingsReducer';
 import SelectDropdown from 'react-native-select-dropdown';
 import Slider from '@react-native-community/slider';
 import { FileScanner } from '@/scripts/FileScanner';
@@ -31,6 +31,7 @@ export default function SettingsPrompt() {
   const [viewOrientation, setLocalViewOrientation] = useState("" as viewOrientations);
   const [viewScale, setLocalViewScale] = useState(2);
   const [defaultPage, setLocalDefaultPage] = useState("home" as defaultPages);
+  const [enableThumbnailGeneration, setLocalEnableThumbnailGeneration] = useState(false);
 
   const dispatch = useDispatch();
   const settingsPassword = useSelector(selectPassword);
@@ -41,6 +42,7 @@ export default function SettingsPrompt() {
   const settingsViewOrientation = useSelector(selectViewOrientation);
   const settingsViewScale = useSelector(selectViewScale);
   const settingsDefaultPage = useSelector(selectDefaultPage);
+  const settingsEnableThumbnailGeneration = useSelector(selectEnableThumbnailGeneration);
   
   const dataSourceRef = useRef(null);
   const mediaStructureRef = useRef(null);
@@ -70,7 +72,7 @@ export default function SettingsPrompt() {
   ];
 
   useEffect(() => {
-    logger.log('Settings', `Screen mounted. Current state: dataSource=${settingsDataSource}, mediaStructure=${settingsMediaStructure}, viewOrientation=${settingsViewOrientation}, viewScale=${settingsViewScale}, sources=${mediaSources.length}`);
+    logger.log('Settings', `Screen mounted. Current state: dataSource=${settingsDataSource}, mediaStructure=${settingsMediaStructure}, viewOrientation=${settingsViewOrientation}, viewScale=${settingsViewScale}, sources=${mediaSources.length}, thumbnails=${settingsEnableThumbnailGeneration}`);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -81,8 +83,9 @@ export default function SettingsPrompt() {
     if (mediaStructureRef.current) (mediaStructureRef.current as any).selectIndex(viewTypeOptions.findIndex(o => o.id === settingsMediaStructure));
     if (viewOrientationRef.current) (viewOrientationRef.current as any).selectIndex(uiTypeOptions.findIndex(o => o.id === settingsViewOrientation));
     if (defaultPageRef.current) (defaultPageRef.current as any).selectIndex(defaultPageOptions.findIndex(o => o.id === settingsDefaultPage));
+    setLocalEnableThumbnailGeneration(settingsEnableThumbnailGeneration);
     setStructureDescription(viewTypeOptions.find(o => o.id === settingsMediaStructure)?.title ?? "");
-  }, [settingsPassword, settingsTmdbApiKey, settingsDataSource, settingsMediaStructure, settingsViewOrientation, settingsViewScale, settingsDefaultPage]);
+  }, [settingsPassword, settingsTmdbApiKey, settingsDataSource, settingsMediaStructure, settingsViewOrientation, settingsViewScale, settingsDefaultPage, settingsEnableThumbnailGeneration]);
 
   const save = () => {
     logger.log('Settings', 'Save pressed – evaluating changes');
@@ -121,6 +124,11 @@ export default function SettingsPrompt() {
     if (defaultPage && defaultPage !== settingsDefaultPage) {
       logger.log('Settings', `Persisting: defaultPage changed ${settingsDefaultPage} → ${defaultPage}`);
       dispatch(setDefaultPage(defaultPage));
+      changeCount++;
+    }
+    if (enableThumbnailGeneration !== settingsEnableThumbnailGeneration) {
+      logger.log('Settings', `Persisting: enableThumbnailGeneration changed ${settingsEnableThumbnailGeneration} → ${enableThumbnailGeneration}`);
+      dispatch(setEnableThumbnailGeneration(enableThumbnailGeneration));
       changeCount++;
     }
     logger.log('Settings', `Save complete – ${changeCount} setting(s) changed and persisted`);
@@ -229,6 +237,20 @@ export default function SettingsPrompt() {
       {/* Rescan */}
       <ThemedView style={styles.titleContainer}>
         <Button title="Rescan now" onPress={scanNow} />
+      </ThemedView>
+
+      {/* Thumbnail generation */}
+      <ThemedView style={styles.sectionContainer}>
+        <ThemedView style={styles.titleContainer}>
+          <ThemedText>Generate video thumbnails:</ThemedText>
+          <Switch
+            value={enableThumbnailGeneration}
+            onValueChange={setLocalEnableThumbnailGeneration}
+          />
+        </ThemedView>
+        <ThemedText style={styles.emptyText}>
+          Disabled by default. When off, scans skip thumbnail generation.
+        </ThemedText>
       </ThemedView>
 
       {/* Media structure */}

--- a/src/scripts/FileScanner.ts
+++ b/src/scripts/FileScanner.ts
@@ -178,26 +178,31 @@ export class FileScanner {
             ...allTvFiles.map(({ relativePathParts, ...obj }) => obj),
             ...allMovieFiles.map(({ relativePathParts, ...obj }) => obj),
         ];
-        const uncached = allMediaFiles.filter((m) => !thumbnailCache.has(m.path));
-        logger.log('FileScanner', `Generating thumbnails for ${uncached.length} uncached file(s) (${allMediaFiles.length - uncached.length} already cached)`);
-        let thumbSuccess = 0;
-        let thumbFail = 0;
-        await Promise.allSettled(
-            uncached.map(async (media) => {
-                try {
-                    const thumbnail = await this.generateThumbnail(media.path);
-                    if (!thumbnail) {
-                        throw new Error('No thumbnail returned by expo-video');
+        const enableThumbnailGeneration = store.getState().settingsReducer.enableThumbnailGeneration ?? false;
+        if (enableThumbnailGeneration) {
+            const uncached = allMediaFiles.filter((m) => !thumbnailCache.has(m.path));
+            logger.log('FileScanner', `Generating thumbnails for ${uncached.length} uncached file(s) (${allMediaFiles.length - uncached.length} already cached)`);
+            let thumbSuccess = 0;
+            let thumbFail = 0;
+            await Promise.allSettled(
+                uncached.map(async (media) => {
+                    try {
+                        const thumbnail = await this.generateThumbnail(media.path);
+                        if (!thumbnail) {
+                            throw new Error('No thumbnail returned by expo-video');
+                        }
+                        thumbnailCache.set(media.path, thumbnail);
+                        thumbSuccess++;
+                    } catch (e) {
+                        thumbFail++;
+                        logger.warn('FileScanner', `Thumbnail failed for ${media.filename}`, e);
                     }
-                    thumbnailCache.set(media.path, thumbnail);
-                    thumbSuccess++;
-                } catch (e) {
-                    thumbFail++;
-                    logger.warn('FileScanner', `Thumbnail failed for ${media.filename}`, e);
-                }
-            }),
-        );
-        logger.log('FileScanner', `Thumbnail generation done: ${thumbSuccess} succeeded, ${thumbFail} failed`);
+                }),
+            );
+            logger.log('FileScanner', `Thumbnail generation done: ${thumbSuccess} succeeded, ${thumbFail} failed`);
+        } else {
+            logger.log('FileScanner', 'Thumbnail generation disabled in settings – skipping thumbnail generation step');
+        }
 
         // Enrich library with TMDB posters if an API key is configured
         const tmdbApiKey = store.getState().settingsReducer.tmdbApiKey;

--- a/src/store/settingsReducer.ts
+++ b/src/store/settingsReducer.ts
@@ -22,6 +22,7 @@ interface SettingsState {
   viewOrientation: viewOrientations
   tmdbApiKey: string | null
   defaultPage: defaultPages
+  enableThumbnailGeneration: boolean
 }
 
 // Define the initial state using that type
@@ -34,6 +35,7 @@ const initialState: SettingsState = {
   viewOrientation: 'poster',
   tmdbApiKey: null,
   defaultPage: 'home',
+  enableThumbnailGeneration: false,
 }
 
 export const settingsSlice = createSlice({
@@ -69,10 +71,13 @@ export const settingsSlice = createSlice({
     setDefaultPage: (state, action: PayloadAction<defaultPages>) => {
       state.defaultPage = action.payload;
     },
+    setEnableThumbnailGeneration: (state, action: PayloadAction<boolean>) => {
+      state.enableThumbnailGeneration = action.payload;
+    },
   },
 })
 
-export const { addMediaSource, removeMediaSource, setPassword, setDataSource, setMediaStructure, setViewOrientation, setViewScale, setTmdbApiKey, setDefaultPage } = settingsSlice.actions;
+export const { addMediaSource, removeMediaSource, setPassword, setDataSource, setMediaStructure, setViewOrientation, setViewScale, setTmdbApiKey, setDefaultPage, setEnableThumbnailGeneration } = settingsSlice.actions;
 
 // Other code such as selectors can use the imported `RootState` type
 export const selectMediaSources = (state: RootState) => state.settingsReducer.mediaSources;
@@ -83,5 +88,6 @@ export const selectViewOrientation = (state: RootState) => state.settingsReducer
 export const selectViewScale = (state: RootState) => state.settingsReducer.viewScale;
 export const selectTmdbApiKey = (state: RootState) => state.settingsReducer.tmdbApiKey;
 export const selectDefaultPage = (state: RootState) => state.settingsReducer.defaultPage ?? 'home';
+export const selectEnableThumbnailGeneration = (state: RootState) => state.settingsReducer.enableThumbnailGeneration ?? false;
 
 export default settingsSlice.reducer


### PR DESCRIPTION
This pull request adds a new user-configurable setting for enabling or disabling video thumbnail generation during media scans. The setting is integrated into both the first-time setup and the main settings screens, and the `FileScanner` logic is updated to respect this preference. Redux state management is extended to support the new setting.

**Settings infrastructure and Redux state:**
- Added a new `enableThumbnailGeneration` boolean to the Redux `SettingsState`, with corresponding actions and selectors for updating and accessing the value. The default is set to `false`. [[1]](diffhunk://#diff-26eaceff8057fcb14c69c2adb85cd7ab8eaa09ebb9b5ea458d326ca004044fa8R25) [[2]](diffhunk://#diff-26eaceff8057fcb14c69c2adb85cd7ab8eaa09ebb9b5ea458d326ca004044fa8R38) [[3]](diffhunk://#diff-26eaceff8057fcb14c69c2adb85cd7ab8eaa09ebb9b5ea458d326ca004044fa8R74-R80) [[4]](diffhunk://#diff-26eaceff8057fcb14c69c2adb85cd7ab8eaa09ebb9b5ea458d326ca004044fa8R91)

**First-time setup flow:**
- Updated `src/app/firsttime.tsx` to include a toggle switch for "Generate video thumbnails", storing the user's choice in Redux and displaying a note that it can be changed later in Settings. [[1]](diffhunk://#diff-53ce054896f229835e5561a8d7ba0ab660aa00420bfcccbe59a9bd4d17f46246L1-R1) [[2]](diffhunk://#diff-53ce054896f229835e5561a8d7ba0ab660aa00420bfcccbe59a9bd4d17f46246L12-R19) [[3]](diffhunk://#diff-53ce054896f229835e5561a8d7ba0ab660aa00420bfcccbe59a9bd4d17f46246R29-R33) [[4]](diffhunk://#diff-53ce054896f229835e5561a8d7ba0ab660aa00420bfcccbe59a9bd4d17f46246R70-R79)

**Settings screen:**
- Added a switch for thumbnail generation to `src/app/settings.tsx`, syncing it with Redux state and persisting changes when the user saves settings. [[1]](diffhunk://#diff-daddbf899c8d5301534efa688b13b7dc59ac1f562b26d06c417e98ef67f0979eL2-R10) [[2]](diffhunk://#diff-daddbf899c8d5301534efa688b13b7dc59ac1f562b26d06c417e98ef67f0979eR34) [[3]](diffhunk://#diff-daddbf899c8d5301534efa688b13b7dc59ac1f562b26d06c417e98ef67f0979eR45) [[4]](diffhunk://#diff-daddbf899c8d5301534efa688b13b7dc59ac1f562b26d06c417e98ef67f0979eL73-R75) [[5]](diffhunk://#diff-daddbf899c8d5301534efa688b13b7dc59ac1f562b26d06c417e98ef67f0979eR86-R88) [[6]](diffhunk://#diff-daddbf899c8d5301534efa688b13b7dc59ac1f562b26d06c417e98ef67f0979eR129-R133) [[7]](diffhunk://#diff-daddbf899c8d5301534efa688b13b7dc59ac1f562b26d06c417e98ef67f0979eR242-R255)

**File scanning logic:**
- Updated `FileScanner` to check the `enableThumbnailGeneration` setting and skip or perform thumbnail generation accordingly, logging the behavior for clarity. [[1]](diffhunk://#diff-bb81a16858b5a3ed2c2f1d591888aa8af9385c383e57949c2aea81fecbfb8382R181-R182) [[2]](diffhunk://#diff-bb81a16858b5a3ed2c2f1d591888aa8af9385c383e57949c2aea81fecbfb8382R203-R205)